### PR TITLE
Add support for CountMinSketch to increment counter by a given number

### DIFF
--- a/lib/countMinSketch.js
+++ b/lib/countMinSketch.js
@@ -81,8 +81,15 @@ function CountMinSketch(maxEntries, epsilon, delta, lgWidth, counts, hashFunctio
   /**
    * Record an observation of the given key.
    * @param {String} key Key to increment the observation count for.
+   * @param {Number} incrementBy Number to increment counter by
    */
-  function increment(key) {
+  function increment(key, incrementBy=1) {
+    if (incrementBy < 0) {
+      throw new Error(`Can't increment by a negative number`);
+    } else if (incrementBy === 0) {
+      return;
+    }
+
     // Map the key to an integer value
     var ix = hashing.fnv1a(key);
     var est = MAX_INT;
@@ -100,11 +107,11 @@ function CountMinSketch(maxEntries, epsilon, delta, lgWidth, counts, hashFunctio
     for (i = 0; i < hashFunctions.length; i++) {
       j = multiplyShift(lgWidth, hashFunctions[i], ix);
       if (counts[i][j] === est)
-        counts[i][j] = est + 1;
+        counts[i][j] = est + incrementBy;
     }
 
     // Update the priority queue with the updated [count, key] tuple
-    updateHeap(key, est + 1);
+    updateHeap(key, est + incrementBy);
   }
 
   function updateHeap(key, est) {

--- a/lib/countMinSketch.js
+++ b/lib/countMinSketch.js
@@ -84,12 +84,6 @@ function CountMinSketch(maxEntries, epsilon, delta, lgWidth, counts, hashFunctio
    * @param {Number} incrementBy Number to increment counter by
    */
   function increment(key, incrementBy=1) {
-    if (incrementBy < 0) {
-      throw new Error(`Can't increment by a negative number`);
-    } else if (incrementBy === 0) {
-      return;
-    }
-
     // Map the key to an integer value
     var ix = hashing.fnv1a(key);
     var est = MAX_INT;

--- a/test/countminsketch-test.js
+++ b/test/countminsketch-test.js
@@ -30,15 +30,13 @@ vows.describe('CountMinSketch').addBatch({
     'can increment by a given number': function(cms) {
       cms.increment('4d6e5acebcd1b3fac0000000', 2);
       cms.increment('4d6e5acebcd1b3fac0000000', 3);
+      cms.increment('4d6e5acebcd1b3fac0000000', -1);
       cms.increment('4d6e5acebcd1b3fac0000000', 0);
 
       var top = cms.getTopK();
       assert.equal(top.length, 1);
-      assert.equal(top[0][0], 8);
+      assert.equal(top[0][0], 7);
       assert.equal(top[0][1], '4d6e5acebcd1b3fac0000000');
-    },
-    'returns an exception when increment number is negative': function(cms) {
-      assert.throws(() => cms.increment('4d6e5acebcd1b3fac0000000', -2), Error);
     },
     'can add 1000000': function(cms) {
       var i;

--- a/test/countminsketch-test.js
+++ b/test/countminsketch-test.js
@@ -18,7 +18,7 @@ vows.describe('CountMinSketch').addBatch({
       assert.equal(top[0][0], 1);
       assert.equal(top[0][1], '4d6e5acebcd1b3fac0000000');
     },
-    'can increment': function(cms) {
+    'can increment by 1': function(cms) {
       cms.increment('4d6e5acebcd1b3fac0000000');
       cms.increment('4d6e5acebcd1b3fac0000000');
 
@@ -26,6 +26,19 @@ vows.describe('CountMinSketch').addBatch({
       assert.equal(top.length, 1);
       assert.equal(top[0][0], 3);
       assert.equal(top[0][1], '4d6e5acebcd1b3fac0000000');
+    },
+    'can increment by a given number': function(cms) {
+      cms.increment('4d6e5acebcd1b3fac0000000', 2);
+      cms.increment('4d6e5acebcd1b3fac0000000', 3);
+      cms.increment('4d6e5acebcd1b3fac0000000', 0);
+
+      var top = cms.getTopK();
+      assert.equal(top.length, 1);
+      assert.equal(top[0][0], 8);
+      assert.equal(top[0][1], '4d6e5acebcd1b3fac0000000');
+    },
+    'returns an exception when increment number is negative': function(cms) {
+      assert.throws(() => cms.increment('4d6e5acebcd1b3fac0000000', -2), Error);
     },
     'can add 1000000': function(cms) {
       var i;


### PR DESCRIPTION
This new functionality serves the purpose of performing count-min sketch computation in distributed environment where output of multiple workers/mappers (map/reduce) needs to be merged into and aggregated centrally by reducer